### PR TITLE
[WIP] enable easier local debugging: add mock auth provider + disable SSL verification

### DIFF
--- a/auth/lib.py
+++ b/auth/lib.py
@@ -2,6 +2,7 @@ from urllib.parse import urljoin
 
 import jwt
 import requests
+import os
 
 
 class Verifyer:
@@ -9,7 +10,9 @@ class Verifyer:
     def __init__(self, *, auth_endpoint=None, public_key=None):
         if public_key is None:
             if auth_endpoint is not None:
-                public_key = requests.get(urljoin(auth_endpoint, 'public-key')).text
+                public_key = requests.get(urljoin(auth_endpoint, 'public-key'),
+                                          # verify ssl - defaults to true
+                                          verify=(os.environ.get("VERIFY_SSL")!="0")).text
         assert public_key is not None
         self.public_key = public_key
 

--- a/auth/models.py
+++ b/auth/models.py
@@ -21,6 +21,7 @@ _sql_session = None
 
 def setup_engine(connection_string):
     global _sql_engine
+    assert connection_string, "No database defined, please set your DATABASE_URL environment variable"
     _sql_engine = create_engine(connection_string)
     Base.metadata.create_all(_sql_engine)
 


### PR DESCRIPTION
**work in progress - don't merge**

## reproduction steps
* have some problems with auth server
* want to debug them

### expected
* set environment variables:
  * `ENABLE_MOCK_OAUTH=1`
  * `VERIFY_SSL=0`
* run the server
  * server will return an additional `mock` provider that will behave the same as other providers but not actually authenticate
  * when making requests from [Verifyer](https://github.com/datahq/auth/blob/master/auth/lib.py#L12) - add verify=False to `requests.get` to enable using it with self-issued SSL certificate
* able to debug quickly eliminating 3rd party oauth provider problems

### actual
* very hard to debug auth server locally
